### PR TITLE
make mobile icons configurable through experience fragments 

### DIFF
--- a/core/src/main/java/com/adobe/guides/aem/components/core/models/CopyLinkComponentModel.java
+++ b/core/src/main/java/com/adobe/guides/aem/components/core/models/CopyLinkComponentModel.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class CopyLinkComponentModel implements ComponentExporter {
 
-    public static final String RESOURCE_TYPE = "guides-components/components/copy-link-component";
+    public static final String RESOURCE_TYPE = "guides-components/components/copy-link";
 
     @ValueMapValue
     private String copyLinkIcon;

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-fsi/js/navigation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-fsi/js/navigation.js
@@ -80,8 +80,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 let nested = item.closest("li").querySelector("ul");
                 if(nested) {
                     nested.classList.add("tree");
-                } else {
-                    nested.classList.remove("tree");
                 }
             } 
         }); 

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-hitech/js/navigation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-hitech/js/navigation.js
@@ -64,8 +64,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 let nested = item.closest("li").querySelector("ul");
                 if(nested) {
                     nested.classList.add("tree");
-                } else {
-                    nested.classList.remove("tree");
                 }
             }
         });

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-manufacturing/js/navigation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-manufacturing/js/navigation.js
@@ -128,8 +128,6 @@ document.addEventListener("DOMContentLoaded", function () {
             let nested = item.closest("li").querySelector("ul");
             if (nested) {
               nested.classList.add("tree");
-            } else {
-              nested.classList.remove("tree");
             }
           }
         });

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-manufacturing/js/theme-selector.js
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/clientlibs/clientlib-hfm/clientlib-base-manufacturing/js/theme-selector.js
@@ -9,7 +9,8 @@ window.onload = function () {
 
     const $lightIcon = $themIcon.querySelector(".gu-theme_icon.light");
     const $darkIcon = $themIcon.querySelector(".gu-theme_icon.dark");
-
+	
+	/*
     // Select the dark theme icon and update its src
     $darkIcon.src =
       "/content/dam/guides/common-images/icons/manufacturing-dark-theme.svg";
@@ -17,7 +18,8 @@ window.onload = function () {
     // Select the light theme icon and update its src
     $lightIcon.src =
       "/content/dam/guides/common-images/icons/manufacturing-light-theme.svg";
-
+	*/
+	
     if (theme === "dark") {
       document.body.classList.add("dark");
       document.body.classList.remove("light");

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/fsi/fsi-guides-component-config-xfpage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/fsi/fsi-guides-component-config-xfpage/body.html
@@ -27,7 +27,7 @@
         </div>
         <div class="gu-search__container">
           <button class="gu-search__toggle" aria-label="Search">
-            <img class="gu-search__icon" src="${toolbarConfig.searchIcon}" alt="Search Icon"/>
+            <img class="gu-search__icon" src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}" alt="Search Icon"/>
           </button>
         </div>
         <div class="language-navigation" data-sly-test="${toolbarConfig.embedLanguageNavigation}">
@@ -70,15 +70,15 @@
       <div class="toolbar-wrapper">
         <div class="left-section">
           <button class="layout-button">
-            <img src="/content/dam/guides/common-images/icons/navigation-section.svg" alt="Layout button"/>
+            <img src="${toolbarConfig.mobNavIcon ? toolbarConfig.mobNavIcon : '/content/dam/guides/common-images/icons/navigation-section.svg'}" alt="Layout button"/>
           </button>
           <button class="toc-button">
-            <img src="/content/dam/guides/common-images/icons/toc.svg" alt="Toc button"/>
+            <img src="${toolbarConfig.tocIcon ? toolbarConfig.tocIcon : '/content/dam/guides/common-images/icons/toc.svg'}" alt="Toc button"/>
           </button>
         </div>
         <div class="right-section">
           <button class="lat-button">
-            <img src="/content/dam/guides/common-images/icons/Kebab.svg" alt="Lat button"/>
+            <img src="${toolbarConfig.latButtonIcon ? toolbarConfig.latButtonIcon : '/content/dam/guides/common-images/icons/Kebab.svg'}" alt="Lat button"/>
           </button>
         </div>
       </div>
@@ -86,19 +86,19 @@
       <div class="lat-section hidden">
         <div class="lat-closewarpper">
           <button class="lat-closebutton">
-            <img src="/content/dam/guides/common-images/icons/cross.svg" alt="Lat close icon"/>
+            <img src="${toolbarConfig.latCloseIcon ? toolbarConfig.latCloseIcon : '/content/dam/guides/common-images/icons/cross.svg'}" alt="Lat close icon"/>
           </button>
         </div>
         <div class="gu-language-navigation-toolbar" data-sly-test="${toolbarConfig.embedLanguageNavigation}">
           <div class="gu-language-navigation__title-container">
-            <img class="gu-language-navigation_icon" src="/content/dam/guides/common-images/icons/language.svg" alt="Language Navigation Icon"/>
+            <img class="gu-language-navigation_icon" src="${toolbarConfig.languageIcon ? toolbarConfig.languageIcon : '/content/dam/guides/common-images/icons/language.svg'}" alt="Language Navigation Icon"/>
             <span>Language</span>
           </div>
           <sly data-sly-resource="${'toolbar/language-navigation' @ resourceType='guides-components/components/languagenavigation2'}"/>
         </div>
         <div class="gu-accessibility-toolbar" data-sly-test="${toolbarConfig.embedAccessibility}">
           <div class="gu-accessibility__title-container">
-            <img class="gu-accessibility_icon" src="/content/dam/guides/common-images/icons/accessibility.svg" alt="Accessibility Icon"/>
+            <img class="gu-accessibility_icon" src="${toolbarConfig.accessibilityIcon ? toolbarConfig.accessibilityIcon : '/content/dam/guides/common-images/icons/accessibility.svg'}" alt="Accessibility Icon"/>
             <span>Accessibility</span>
           </div>
           <sly data-sly-resource="${'toolbar/accessibility' @ resourceType='guides-components/components/accessibility'}"/>
@@ -108,7 +108,7 @@
     <div class="toolbar below-title mobile hidden">
       <div class="gu-search__container">
         <button class="gu-search__toggle" aria-label="Search">
-          <img class="gu-search__icon" src="/content/dam/guides/common-images/icons/search-icon.png" alt="Search Icon"/>
+          <img class="gu-search__icon" src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}" alt="Search Icon"/>
         </button>
       </div>
       <div class="theme-selector" data-sly-test="${toolbarConfig.embedThemeSelector}">

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/hitech/hitech-guides-component-config-xfpage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/hitech/hitech-guides-component-config-xfpage/body.html
@@ -59,7 +59,7 @@
     <div class="toolbar toolbar-header mobile hidden">
       <div class="gu-search__container">
         <button class="gu-search__toggle" aria-label="Search">
-          <img class="gu-search__icon" src="${toolbarConfig.searchIcon}" alt="Search Icon"/>
+          <img class="gu-search__icon" src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}" alt="Search Icon"/>
         </button>
       </div>
       <div class="accessibility" data-sly-test="${toolbarConfig.embedAccessibility}">
@@ -76,7 +76,7 @@
     </div>
     <div class="toolbar sticky-middle mobile hidden">
       <button class="layout-button">
-        <img src="${toolbarConfig.mobNavIcon}" alt="Layout button"/>
+        <img src="${toolbarConfig.mobNavIcon ? toolbarConfig.mobNavIcon : '/content/dam/guides/common-images/icons/navigation-section.svg'}" alt="Layout button"/>
       </button>
       <div class="pdf-export" data-sly-test="${toolbarConfig.embedPdfExport}">
         <sly data-sly-resource="${'toolbar/pdf-export' @ resourceType='guides-components/components/pdf-export'}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
@@ -131,13 +131,13 @@
         <div class="left-section">
           <button class="layout-button">
             <img
-              src="${toolbarConfig.mobNavIcon ? toolbarConfig.mobNavIcon : '/content/dam/guides/common-images/icons/navigation-section.svg'}"
+              src="${toolbarConfig.mobNavIcon ? toolbarConfig.mobNavIcon : '/content/dam/guides/common-images/icons/manufacturinng-navigation-icon.svg'}"
               alt="Layout button"
             />
           </button>
           <button class="toc-button">
             <img
-              src="${toolbarConfig.tocIcon ? toolbarConfig.tocIcon : '/content/dam/guides/common-images/icons/toc.svg'}"
+              src="${toolbarConfig.tocIcon ? toolbarConfig.tocIcon : '/content/dam/guides/common-images/icons/manufacturinng-toc-icon.svg'}"
               alt="Toc button"
             />
           </button>
@@ -145,7 +145,7 @@
         <div class="right-section">
           <button class="lat-button">
             <img
-              src="${toolbarConfig.latButtonIcon ? toolbarConfig.latButtonIcon : '/content/dam/guides/common-images/icons/Kebab.svg'}"
+              src="${toolbarConfig.latButtonIcon ? toolbarConfig.latButtonIcon : '/content/dam/guides/common-images/icons/manufacturing-kebab.svg'}"
               alt="Lat button"
             />
           </button>
@@ -200,7 +200,7 @@
         <button class="gu-search__toggle" aria-label="Search">
           <img
             class="gu-search__icon"
-            src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}"
+            src="${toolbarConfig.searchHeaderIcon ? toolbarConfig.searchHeaderIcon : '/content/dam/guides/common-images/icons/searchheader.svg'}"
             alt="Search Icon"
           />
         </button>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
@@ -131,13 +131,13 @@
         <div class="left-section">
           <button class="layout-button">
             <img
-              src="/content/dam/guides/common-images/icons/manufacturinng-navigation-icon.svg"
+              src="${toolbarConfig.mobNavIcon ? toolbarConfig.mobNavIcon : '/content/dam/guides/common-images/icons/navigation-section.svg'}"
               alt="Layout button"
             />
           </button>
           <button class="toc-button">
             <img
-              src="/content/dam/guides/common-images/icons/manufacturinng-toc-icon.svg"
+              src="${toolbarConfig.tocIcon ? toolbarConfig.tocIcon : '/content/dam/guides/common-images/icons/toc.svg'}"
               alt="Toc button"
             />
           </button>
@@ -145,7 +145,7 @@
         <div class="right-section">
           <button class="lat-button">
             <img
-              src="/content/dam/guides/common-images/icons/manufacturing-kebab.svg"
+              src="${toolbarConfig.latButtonIcon ? toolbarConfig.latButtonIcon : '/content/dam/guides/common-images/icons/Kebab.svg'}"
               alt="Lat button"
             />
           </button>
@@ -156,7 +156,7 @@
         <div class="lat-closewarpper">
           <button class="lat-closebutton">
             <img
-              src="/content/dam/guides/common-images/icons/cross.svg"
+              src="${toolbarConfig.latCloseIcon ? toolbarConfig.latCloseIcon : '/content/dam/guides/common-images/icons/cross.svg'}"
               alt="Lat close icon"
             />
           </button>
@@ -168,7 +168,7 @@
           <div class="gu-language-navigation__title-container">
             <img
               class="gu-language-navigation_icon"
-              src="/content/dam/guides/common-images/icons/language.svg"
+              src="${toolbarConfig.languageIcon ? toolbarConfig.languageIcon : '/content/dam/guides/common-images/icons/language.svg'}"
               alt="Language Navigation Icon"
             />
             <span>Language</span>
@@ -184,7 +184,7 @@
           <div class="gu-accessibility__title-container">
             <img
               class="gu-accessibility_icon"
-              src="/content/dam/guides/common-images/icons/accessibility.svg"
+              src="${toolbarConfig.accessibilityIcon ? toolbarConfig.accessibilityIcon : '/content/dam/guides/common-images/icons/accessibility.svg'}"
               alt="Accessibility Icon"
             />
             <span>Accessibility</span>
@@ -200,7 +200,7 @@
         <button class="gu-search__toggle" aria-label="Search">
           <img
             class="gu-search__icon"
-            src="/content/dam/guides/common-images/icons/searchheader.svg"
+            src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}"
             alt="Search Icon"
           />
         </button>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/guides-pages/manufacturing/manufacturing-guides-component-config-xfpage/body.html
@@ -48,7 +48,7 @@
           <button class="gu-search__toggle" aria-label="Search">
             <img
               class="gu-search__icon"
-              src="/content/dam/guides/common-images/icons/search-icon.png"
+              src="${toolbarConfig.searchIcon ? toolbarConfig.searchIcon : '/content/dam/guides/common-images/icons/search-icon.png'}"
               alt="Search Icon"
             />
           </button>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/languagenavigation2/languagenavigation2.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/languagenavigation2/languagenavigation2.html
@@ -8,7 +8,7 @@
         data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
         data-sly-use.groupTemplate="group.html" data-sly-call="${groupTemplate.group @ items=languageNavigation.items}"
         data-sly-test.hasContent="${languageNavigation.items.size > 0}"
-        data-cmp-data-layer="${languageNavigation.data.json}" id="${languageNavigation.id}"
+        data-cmp-data-layer="${languageNavigation.data.json}" class="language-selector__dropdown"
         class="cmp-languagenavigation" aria-label="${languageNavigation.accessibilityLabel}" role="navigation">
     </nav>
 </div>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/languagenavigation2/languagenavigation2.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/languagenavigation2/languagenavigation2.html
@@ -8,7 +8,7 @@
         data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
         data-sly-use.groupTemplate="group.html" data-sly-call="${groupTemplate.group @ items=languageNavigation.items}"
         data-sly-test.hasContent="${languageNavigation.items.size > 0}"
-        data-cmp-data-layer="${languageNavigation.data.json}" class="language-selector__dropdown"
+        data-cmp-data-layer="${languageNavigation.data.json}" id="${languageNavigation.id}" class="language-selector__dropdown"
         class="cmp-languagenavigation" aria-label="${languageNavigation.accessibilityLabel}" role="navigation">
     </nav>
 </div>

--- a/ui.apps/src/main/content/jcr_root/apps/guides-components/components/pdf-export/pdf-export.html
+++ b/ui.apps/src/main/content/jcr_root/apps/guides-components/components/pdf-export/pdf-export.html
@@ -15,7 +15,7 @@
   <div class="gu-pdf-export__dropdown">
     <ul class="gu-pdf-export__options">
       <li>
-        <a id="gu-pdf_topic-download" target="_blank" download>${'This Topic' @ i18n}</a>
+        <a class="gu-pdf_topic-download" target="_blank" download>${'This Topic' @ i18n}</a>
       </li>
       <li>
         <a href="${pdfExport.pdfPath}" target="_blank" download>${'Entire Document' @ i18n}</a>


### PR DESCRIPTION
some of the DAM paths to icons in the manufacturing and fsi page components are hardcoded and must be made configurable to make these icons show up in Sites created on cloud instances.

however, i had taken care to put fallback to the original hardcoded path when the corresponding icon path is not configured in the experience fragment

also made minor corrections where required to make the authored icons appear on page